### PR TITLE
Position counting rule

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -198,9 +198,51 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
+/// Mate with KBN vs K.
 template<>
-Value Endgame<KNQK>::operator()(const Position&) const { return VALUE_DRAW; }
+Value Endgame<KBNK>::operator()(const Position& pos) const {
 
+  assert(verify_material(pos, strongSide, KnightValueMg + BishopValueMg, 0));
+  assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
+
+  Square winnerKSq = pos.square<KING>(strongSide);
+  Square loserKSq = pos.square<KING>(weakSide);
+
+  Value result =  VALUE_KNOWN_WIN
+                + PushClose[distance(winnerKSq, loserKSq)]
+                + PushToOpposingSideEdges[strongSide == WHITE ? loserKSq : ~loserKSq];
+
+  return strongSide == pos.side_to_move() ? result : -result;
+}
+
+/// Mate with KNQ vs K.
+template<>
+Value Endgame<KNQK>::operator()(const Position& pos) const {
+
+  assert(verify_material(pos, strongSide, KnightValueMg + QueenValueMg, 0));
+  assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
+
+  Square winnerKSq = pos.square<KING>(strongSide);
+  Square loserKSq = pos.square<KING>(weakSide);
+  Square queenSq = pos.square<QUEEN>(strongSide);
+
+  // tries to drive toward corners A1 or H8. If we have a
+  // queen that cannot reach the above squares, we flip the kings in order
+  // to drive the enemy toward corners A8 or H1.
+  if (opposite_colors(queenSq, SQ_A1))
+  {
+      winnerKSq = ~winnerKSq;
+      loserKSq  = ~loserKSq;
+  }
+
+  Value result =  VALUE_KNOWN_WIN
+                + PushClose[distance(winnerKSq, loserKSq)]
+                + PushToQueenCorners[loserKSq];
+
+  return strongSide == pos.side_to_move() ? result : -result;
+}
+
+/// Mate with KBQ vs K.
 template<>
 Value Endgame<KBQK>::operator()(const Position& pos) const {
 
@@ -209,8 +251,26 @@ Value Endgame<KBQK>::operator()(const Position& pos) const {
 
   Square winnerKSq = pos.square<KING>(strongSide);
   Square loserKSq = pos.square<KING>(weakSide);
+  Square queenSq = pos.square<QUEEN>(strongSide);
+  Value result;
+  if(    (KingCorners[loserKSq] == 1 && !opposite_colors(queenSq, SQ_A1))
+      || (KingCorners[loserKSq] == 2 && !opposite_colors(queenSq, SQ_H1))
+      || (KingCorners[loserKSq] == 3 && !opposite_colors(queenSq, SQ_A8))
+      || (KingCorners[loserKSq] == 4 && !opposite_colors(queenSq, SQ_H8)) )
+  {
+      if (opposite_colors(queenSq, SQ_A1))
+      {
+        winnerKSq = ~winnerKSq;
+        loserKSq  = ~loserKSq;
+      }
 
-  Value result =  VALUE_KNOWN_WIN
+      result =  VALUE_KNOWN_WIN
+                + PushClose[distance(winnerKSq, loserKSq)]
+                + PushToQueenCorners[loserKSq];
+  
+  } else
+
+  result =  VALUE_KNOWN_WIN
                 + PushClose[distance(winnerKSq, loserKSq)]
                 + PushToOpposingSideEdges[strongSide == WHITE ? loserKSq : ~loserKSq];
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -198,23 +198,6 @@ Value Endgame<KBNK>::operator()(const Position& pos) const {
   return strongSide == pos.side_to_move() ? result : -result;
 }
 
-/// Mate with KBN vs K.
-template<>
-Value Endgame<KBNK>::operator()(const Position& pos) const {
-
-  assert(verify_material(pos, strongSide, KnightValueMg + BishopValueMg, 0));
-  assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
-
-  Square winnerKSq = pos.square<KING>(strongSide);
-  Square loserKSq = pos.square<KING>(weakSide);
-
-  Value result =  VALUE_KNOWN_WIN
-                + PushClose[distance(winnerKSq, loserKSq)]
-                + PushToOpposingSideEdges[strongSide == WHITE ? loserKSq : ~loserKSq];
-
-  return strongSide == pos.side_to_move() ? result : -result;
-}
-
 /// Mate with KNQ vs K.
 template<>
 Value Endgame<KNQK>::operator()(const Position& pos) const {

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -42,7 +42,6 @@ enum EndgameCode {
   KBNK,  // KBN vs K
   KBQK,  // KBQ vs K
   KNQK,  // KNQ vs K
-  KPK,   // KP vs K
   KRKP,  // KR vs KP
   KRKB,  // KR vs KB
   KRKN,  // KR vs KN
@@ -52,7 +51,6 @@ enum EndgameCode {
   SCALING_FUNCTIONS,
   KRPKR,   // KRP vs KR
   KRPPKRP, // KRPP vs KRP
-  KPsK,    // K and pawns vs K
   KBPKB,   // KBP vs KB
   KBPPKB,  // KBPP vs KB
   KBPKN,   // KBP vs KN

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -233,7 +233,7 @@ int get_group(size_t idx) {
 
   // Early exit if the needed API is not available at runtime
   HMODULE k32 = GetModuleHandle("Kernel32.dll");
-  auto fun1 = (fun1_t)GetProcAddress(k32, "GetLogicalProcessorInformationEx");
+  auto fun1 = (fun1_t)(void(*)())GetProcAddress(k32, "GetLogicalProcessorInformationEx");
   if (!fun1)
       return -1;
 
@@ -309,8 +309,8 @@ void bindThisThread(size_t idx) {
 
   // Early exit if the needed API are not available at runtime
   HMODULE k32 = GetModuleHandle("Kernel32.dll");
-  auto fun2 = (fun2_t)GetProcAddress(k32, "GetNumaNodeProcessorMaskEx");
-  auto fun3 = (fun3_t)GetProcAddress(k32, "SetThreadGroupAffinity");
+  auto fun2 = (fun2_t)(void(*)())GetProcAddress(k32, "GetNumaNodeProcessorMaskEx");
+  auto fun3 = (fun3_t)(void(*)())GetProcAddress(k32, "SetThreadGroupAffinity");
 
   if (!fun2 || !fun3)
       return;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -216,7 +216,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   gamePly = std::max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
   
   // Honor's rules : BJ
-  st->honor_limit = 64;
+  st->honor_limit = 66;
   st->honor_cnt = count<ALL_PIECES>();
 
   chess960 = isChess960;
@@ -629,7 +629,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       // Reset honor's rule counter
       st->honor_cnt = 0;
   }
-  else if(last_pawn_gone && count<ALL_PIECES>(them) == 1){
+  else if((last_pawn_gone && count<ALL_PIECES>(them) == 1)||counting_limit()>64){
       // Set up counting limit and start counting 
       // when last pawn has gone and opponent only has a bare king
       set_counting_limit();
@@ -718,6 +718,7 @@ void Position::do_null_move(StateInfo& newSt) {
 
   ++st->rule50;
   st->pliesFromNull = 0;
+  ++st->honor_cnt;
 
   sideToMove = ~sideToMove;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -629,7 +629,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       // Reset honor's rule counter
       st->honor_cnt = 0;
   }
-  else if((last_pawn_gone && count<ALL_PIECES>(them) == 1)||counting_limit()>64){
+  else if(count<ALL_PIECES>(them) == 1 && (last_pawn_gone ||counting_limit()>64)){
       // Set up counting limit and start counting 
       // when last pawn has gone and opponent only has a bare king
       set_counting_limit();

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -412,7 +412,7 @@ WDLEntry::WDLEntry(const std::string& code) {
     StateInfo st;
     Position pos;
 
-    memset(this, 0, sizeof(WDLEntry));
+    memset(static_cast<void*>(this), 0, sizeof(WDLEntry));
 
     ready = false;
     key = pos.set(code, WHITE, &st).material_key();
@@ -453,7 +453,7 @@ WDLEntry::~WDLEntry() {
 
 DTZEntry::DTZEntry(const WDLEntry& wdl) {
 
-    memset(this, 0, sizeof(DTZEntry));
+    memset(static_cast<void*>(this), 0, sizeof(DTZEntry));
 
     ready = false;
     key = wdl.key;


### PR DESCRIPTION
**misc.cpp**
Fix warning on MinGW gcc 8.1.0 #1619
https://github.com/official-stockfish/Stockfish/issues/1619
Changing `(fun1_t)` to `(fun1_t)(void(*)())`
and so on
		  
**syzygy/tbprobe.cpp**
Fix warnings on MinGW gcc 8.1.0
Changing `memset(this, 0, sizeof(WDLEntry));` to `memset(static_cast<void*>(this), 0, sizeof(WDLEntry));` 
and so on
		  
**position.h position.cpp endgame.cpp**
Fix honor's rules counting for real game

Leave `rule50_count() ` count 50 moves as normal chess.

But using  `counting_limit()` and `honor_rule_count()` to take care about honor's rule counting for the real game.